### PR TITLE
Bump minimum php version to currently supported

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.phpunit.result.cache
 /clover.xml
 /composer.lock
 /coveralls-upload.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,36 +12,18 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 5.6
+    - php: 7.3
       env:
         - DEPS=lowest
-    - php: 5.6
-      env:
-        - DEPS=latest
-    - php: 7
-      env:
-        - DEPS=lowest
-    - php: 7
-      env:
-        - DEPS=latest
-    - php: 7.1
-      env:
-        - DEPS=lowest
-    - php: 7.1
+    - php: 7.3
       env:
         - DEPS=latest
         - CS_CHECK=true
         - TEST_COVERAGE=true
-    - php: 7.2
+    - php: 7.4
       env:
         - DEPS=lowest
-    - php: 7.2
-      env:
-        - DEPS=latest
-    - php: 7.3
-      env:
-        - DEPS=lowest
-    - php: 7.3
+    - php: 7.4
       env:
         - DEPS=latest
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Removed
 
-- Nothing.
+- [#8](https://github.com/laminas/laminas-modulemanager/pull/8) removes support for PHP versions prior to PHP 7.3.
 
 ### Fixed
 

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "laminas/laminas-loader": "^2.5",
         "laminas/laminas-mvc": "^3.0 || ^2.7",
         "laminas/laminas-servicemanager": "^3.0.3 || ^2.7.5",
-        "phpunit/phpunit": "^9.0"
+        "phpunit/phpunit": "^9.3.7"
     },
     "suggest": {
         "laminas/laminas-console": "Laminas\\Console component",

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "laminas/laminas-loader": "^2.5",
         "laminas/laminas-mvc": "^3.0 || ^2.7",
         "laminas/laminas-servicemanager": "^3.0.3 || ^2.7.5",
-        "phpunit/phpunit": "^5.7.27 || ^6.5.14 || ^7.5.16"
+        "phpunit/phpunit": "^9.0"
     },
     "suggest": {
         "laminas/laminas-console": "Laminas\\Console component",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         }
     },
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.3",
         "laminas/laminas-config": "^3.1 || ^2.6",
         "laminas/laminas-eventmanager": "^3.2 || ^2.6.3",
         "laminas/laminas-stdlib": "^3.1 || ^2.7",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,34 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
          bootstrap="./vendor/autoload.php"
          colors="true">
+    <coverage includeUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </coverage>
     <testsuites>
         <testsuite name="laminas-modulemanager Test Suite">
             <directory>./test/</directory>
         </testsuite>
     </testsuites>
-
-    <groups>
-        <exclude>
-            <group>disable</group>
-        </exclude>
-    </groups>
-
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
-
-    <php>
-        <ini name="date.timezone" value="UTC"/>
-
-        <!-- OB_ENABLED should be enabled for some tests to check if all
-             functionality works as expected. Such tests include those for
-             Laminas\Soap and Laminas\Session, which require that headers not be sent
-             in order to work. -->
-        <env name="TESTS_LAMINAS_OB_ENABLED" value="false" />
-
-    </php>
 </phpunit>

--- a/test/Listener/AutoloaderListenerTest.php
+++ b/test/Listener/AutoloaderListenerTest.php
@@ -38,8 +38,8 @@ class AutoloaderListenerTest extends AbstractListenerTestCase
         $moduleManager->setModules(['ListenerTestModule']);
         $moduleManager->loadModules();
         $modules = $moduleManager->getLoadedModules();
-        $this->assertTrue($modules['ListenerTestModule']->getAutoloaderConfigCalled);
-        $this->assertTrue(class_exists('Foo\Bar'));
+        self::assertTrue($modules['ListenerTestModule']->getAutoloaderConfigCalled);
+        self::assertTrue(class_exists('Foo\Bar'));
     }
     // @codingStandardsIgnoreStart
     public function testAutoloadersRegisteredIfModuleDoesNotInheritAutoloaderProviderInterfaceButDefinesGetAutoloaderConfigMethod()
@@ -48,8 +48,8 @@ class AutoloaderListenerTest extends AbstractListenerTestCase
         $moduleManager->setModules(['NotAutoloaderModule']);
         $moduleManager->loadModules();
         $modules = $moduleManager->getLoadedModules();
-        $this->assertTrue($modules['NotAutoloaderModule']->getAutoloaderConfigCalled);
-        $this->assertTrue(class_exists('Foo\Bar'));
+        self::assertTrue($modules['NotAutoloaderModule']->getAutoloaderConfigCalled);
+        self::assertTrue(class_exists('Foo\Bar'));
     }
    // @codingStandardsIgnoreEnd
 }

--- a/test/Listener/AutoloaderListenerTest.php
+++ b/test/Listener/AutoloaderListenerTest.php
@@ -24,7 +24,7 @@ class AutoloaderListenerTest extends AbstractListenerTestCase
      */
     protected $moduleManager;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->moduleManager = new ModuleManager([]);
         $events = $this->moduleManager->getEventManager();

--- a/test/Listener/ConfigListenerTest.php
+++ b/test/Listener/ConfigListenerTest.php
@@ -32,7 +32,7 @@ class ConfigListenerTest extends AbstractListenerTestCase
      */
     protected $moduleManager;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->moduleManager = new ModuleManager([]);
         $this->moduleManager->getEventManager()->attach(

--- a/test/Listener/ConfigListenerTest.php
+++ b/test/Listener/ConfigListenerTest.php
@@ -52,11 +52,11 @@ class ConfigListenerTest extends AbstractListenerTestCase
         $moduleManager->loadModules();
 
         $config = $configListener->getMergedConfig(false);
-        $this->assertSame(2, count($config));
-        $this->assertSame('test', $config['listener']);
-        $this->assertSame('thing', $config['some']);
+        self::assertSame(2, count($config));
+        self::assertSame('test', $config['listener']);
+        self::assertSame('thing', $config['some']);
         $configObject = $configListener->getMergedConfig();
-        $this->assertInstanceOf('Laminas\Config\Config', $configObject);
+        self::assertInstanceOf('Laminas\Config\Config', $configObject);
     }
 
     public function testCanCacheMergedConfig()
@@ -73,7 +73,7 @@ class ConfigListenerTest extends AbstractListenerTestCase
         $moduleManager->loadModules(); // This should cache the config
 
         $modules = $moduleManager->getLoadedModules();
-        $this->assertTrue($modules['ListenerTestModule']->getConfigCalled);
+        self::assertTrue($modules['ListenerTestModule']->getConfigCalled);
 
         // Now we check to make sure it uses the config and doesn't hit
         // the module objects getConfig() method(s)
@@ -87,7 +87,7 @@ class ConfigListenerTest extends AbstractListenerTestCase
         $configListener->attach($moduleManager->getEventManager());
         $moduleManager->loadModules();
         $modules = $moduleManager->getLoadedModules();
-        $this->assertFalse($modules['ListenerTestModule']->getConfigCalled);
+        self::assertFalse($modules['ListenerTestModule']->getConfigCalled);
     }
 
     public function testBadConfigValueThrowsInvalidArgumentException()
@@ -138,15 +138,15 @@ class ConfigListenerTest extends AbstractListenerTestCase
 
         // Test as object
         $configObject = $configListener->getMergedConfig();
-        $this->assertSame(spl_object_hash($configObjectCheck), spl_object_hash($configObject));
-        $this->assertSame('loaded', $configObject->ini);
-        $this->assertSame('loaded', $configObject->php);
-        $this->assertSame('loaded', $configObject->xml);
+        self::assertSame(spl_object_hash($configObjectCheck), spl_object_hash($configObject));
+        self::assertSame('loaded', $configObject->ini);
+        self::assertSame('loaded', $configObject->php);
+        self::assertSame('loaded', $configObject->xml);
         // Test as array
         $config = $configListener->getMergedConfig(false);
-        $this->assertSame('loaded', $config['ini']);
-        $this->assertSame('loaded', $config['php']);
-        $this->assertSame('loaded', $config['xml']);
+        self::assertSame('loaded', $config['ini']);
+        self::assertSame('loaded', $config['php']);
+        self::assertSame('loaded', $config['xml']);
     }
 
     public function testCanMergeConfigFromStaticPath()
@@ -166,15 +166,15 @@ class ConfigListenerTest extends AbstractListenerTestCase
 
         // Test as object
         $configObject = $configListener->getMergedConfig();
-        $this->assertSame(spl_object_hash($configObjectCheck), spl_object_hash($configObject));
-        $this->assertSame('loaded', $configObject->ini);
-        $this->assertSame('loaded', $configObject->php);
-        $this->assertSame('loaded', $configObject->xml);
+        self::assertSame(spl_object_hash($configObjectCheck), spl_object_hash($configObject));
+        self::assertSame('loaded', $configObject->ini);
+        self::assertSame('loaded', $configObject->php);
+        self::assertSame('loaded', $configObject->xml);
         // Test as array
         $config = $configListener->getMergedConfig(false);
-        $this->assertSame('loaded', $config['ini']);
-        $this->assertSame('loaded', $config['php']);
-        $this->assertSame('loaded', $config['xml']);
+        self::assertSame('loaded', $config['ini']);
+        self::assertSame('loaded', $config['php']);
+        self::assertSame('loaded', $config['xml']);
     }
 
     public function testCanMergeConfigFromStaticPaths()
@@ -196,15 +196,15 @@ class ConfigListenerTest extends AbstractListenerTestCase
 
         // Test as object
         $configObject = $configListener->getMergedConfig();
-        $this->assertSame(spl_object_hash($configObjectCheck), spl_object_hash($configObject));
-        $this->assertSame('loaded', $configObject->ini);
-        $this->assertSame('loaded', $configObject->php);
-        $this->assertSame('loaded', $configObject->xml);
+        self::assertSame(spl_object_hash($configObjectCheck), spl_object_hash($configObject));
+        self::assertSame('loaded', $configObject->ini);
+        self::assertSame('loaded', $configObject->php);
+        self::assertSame('loaded', $configObject->xml);
         // Test as array
         $config = $configListener->getMergedConfig(false);
-        $this->assertSame('loaded', $config['ini']);
-        $this->assertSame('loaded', $config['php']);
-        $this->assertSame('loaded', $config['xml']);
+        self::assertSame('loaded', $config['ini']);
+        self::assertSame('loaded', $config['php']);
+        self::assertSame('loaded', $config['xml']);
     }
 
     public function testCanCacheMergedConfigFromGlob()
@@ -239,12 +239,12 @@ class ConfigListenerTest extends AbstractListenerTestCase
 
         // Check if values from glob object and cache object are the same
         $configObjectFromCache = $configListener->getMergedConfig();
-        $this->assertNotNull($configObjectFromGlob->ini);
-        $this->assertSame($configObjectFromGlob->ini, $configObjectFromCache->ini);
-        $this->assertNotNull($configObjectFromGlob->php);
-        $this->assertSame($configObjectFromGlob->php, $configObjectFromCache->php);
-        $this->assertNotNull($configObjectFromGlob->xml);
-        $this->assertSame($configObjectFromGlob->xml, $configObjectFromCache->xml);
+        self::assertNotNull($configObjectFromGlob->ini);
+        self::assertSame($configObjectFromGlob->ini, $configObjectFromCache->ini);
+        self::assertNotNull($configObjectFromGlob->php);
+        self::assertSame($configObjectFromGlob->php, $configObjectFromCache->php);
+        self::assertNotNull($configObjectFromGlob->xml);
+        self::assertSame($configObjectFromGlob->xml, $configObjectFromCache->xml);
     }
 
     public function testCanCacheMergedConfigFromStatic()
@@ -283,12 +283,12 @@ class ConfigListenerTest extends AbstractListenerTestCase
 
         // Check if values from glob object and cache object are the same
         $configObjectFromCache = $configListener->getMergedConfig();
-        $this->assertNotNull($configObjectFromGlob->ini);
-        $this->assertSame($configObjectFromGlob->ini, $configObjectFromCache->ini);
-        $this->assertNotNull($configObjectFromGlob->php);
-        $this->assertSame($configObjectFromGlob->php, $configObjectFromCache->php);
-        $this->assertNotNull($configObjectFromGlob->xml);
-        $this->assertSame($configObjectFromGlob->xml, $configObjectFromCache->xml);
+        self::assertNotNull($configObjectFromGlob->ini);
+        self::assertSame($configObjectFromGlob->ini, $configObjectFromCache->ini);
+        self::assertNotNull($configObjectFromGlob->php);
+        self::assertSame($configObjectFromGlob->php, $configObjectFromCache->php);
+        self::assertNotNull($configObjectFromGlob->xml);
+        self::assertSame($configObjectFromGlob->xml, $configObjectFromCache->xml);
     }
 
     public function testCanMergeConfigFromArrayOfGlobs()
@@ -308,9 +308,9 @@ class ConfigListenerTest extends AbstractListenerTestCase
 
         // Test as object
         $configObject = $configListener->getMergedConfig();
-        $this->assertSame('loaded', $configObject->ini);
-        $this->assertSame('loaded', $configObject->php);
-        $this->assertSame('loaded', $configObject->xml);
+        self::assertSame('loaded', $configObject->ini);
+        self::assertSame('loaded', $configObject->php);
+        self::assertSame('loaded', $configObject->xml);
     }
 
     public function testCanMergeConfigFromArrayOfStatic()
@@ -330,9 +330,9 @@ class ConfigListenerTest extends AbstractListenerTestCase
 
         // Test as object
         $configObject = $configListener->getMergedConfig();
-        $this->assertSame('loaded', $configObject->ini);
-        $this->assertSame('loaded', $configObject->php);
-        $this->assertSame('loaded', $configObject->xml);
+        self::assertSame('loaded', $configObject->ini);
+        self::assertSame('loaded', $configObject->php);
+        self::assertSame('loaded', $configObject->xml);
     }
 
     public function testMergesWithMergeAndReplaceBehavior()
@@ -351,8 +351,8 @@ class ConfigListenerTest extends AbstractListenerTestCase
         $moduleManager->loadModules();
 
         $mergedConfig = $configListener->getMergedConfig(false);
-        $this->assertSame(['foo', 'bar'], $mergedConfig['indexed']);
-        $this->assertSame('bar', $mergedConfig['keyed']);
+        self::assertSame(['foo', 'bar'], $mergedConfig['indexed']);
+        self::assertSame('bar', $mergedConfig['keyed']);
     }
 
     public function testConfigListenerFunctionsAsAggregateListener()
@@ -361,12 +361,12 @@ class ConfigListenerTest extends AbstractListenerTestCase
 
         $moduleManager = $this->moduleManager;
         $events        = $moduleManager->getEventManager();
-        $this->assertEquals(2, count($this->getEventsFromEventManager($events)));
+        self::assertEquals(2, count($this->getEventsFromEventManager($events)));
 
         $configListener->attach($events);
-        $this->assertEquals(4, count($this->getEventsFromEventManager($events)));
+        self::assertEquals(4, count($this->getEventsFromEventManager($events)));
 
         $configListener->detach($events);
-        $this->assertEquals(2, count($this->getEventsFromEventManager($events)));
+        self::assertEquals(2, count($this->getEventsFromEventManager($events)));
     }
 }

--- a/test/Listener/DefaultListenerAggregateTest.php
+++ b/test/Listener/DefaultListenerAggregateTest.php
@@ -26,7 +26,7 @@ class DefaultListenerAggregateTest extends AbstractListenerTestCase
      */
     protected $defaultListeners;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->defaultListeners = new DefaultListenerAggregate(
             new ListenerOptions([

--- a/test/Listener/DefaultListenerAggregateTest.php
+++ b/test/Listener/DefaultListenerAggregateTest.php
@@ -64,18 +64,18 @@ class DefaultListenerAggregateTest extends AbstractListenerTestCase
             ],
         ];
         foreach ($expectedEvents as $event => $expectedListeners) {
-            $this->assertContains($event, $events);
+            self::assertContains($event, $events);
             $count = 0;
             foreach ($this->getListenersForEvent($event, $moduleManager->getEventManager()) as $listener) {
                 if (is_array($listener)) {
                     $listener = $listener[0];
                 }
                 $listenerClass = get_class($listener);
-                $this->assertContains($listenerClass, $expectedListeners);
+                self::assertContains($listenerClass, $expectedListeners);
                 $count += 1;
             }
 
-            $this->assertSame(count($expectedListeners), $count);
+            self::assertSame(count($expectedListeners), $count);
         }
     }
 
@@ -85,13 +85,13 @@ class DefaultListenerAggregateTest extends AbstractListenerTestCase
         $moduleManager     = new ModuleManager(['ListenerTestModule']);
         $events            = $moduleManager->getEventManager();
 
-        $this->assertEquals(1, count($this->getEventsFromEventManager($events)));
+        self::assertEquals(1, count($this->getEventsFromEventManager($events)));
 
         $listenerAggregate->attach($events);
-        $this->assertEquals(4, count($this->getEventsFromEventManager($events)));
+        self::assertEquals(4, count($this->getEventsFromEventManager($events)));
 
         $listenerAggregate->detach($events);
-        $this->assertEquals(1, count($this->getEventsFromEventManager($events)));
+        self::assertEquals(1, count($this->getEventsFromEventManager($events)));
     }
 
     public function testDefaultListenerAggregateSkipsAutoloadingListenersIfLaminasLoaderIsNotUsed()
@@ -123,17 +123,17 @@ class DefaultListenerAggregateTest extends AbstractListenerTestCase
             ],
         ];
         foreach ($expectedEvents as $event => $expectedListeners) {
-            $this->assertContains($event, $events);
+            self::assertContains($event, $events);
             $count = 0;
             foreach ($this->getListenersForEvent($event, $eventManager) as $listener) {
                 if (is_array($listener)) {
                     $listener = $listener[0];
                 }
                 $listenerClass = get_class($listener);
-                $this->assertContains($listenerClass, $expectedListeners);
+                self::assertContains($listenerClass, $expectedListeners);
                 $count += 1;
             }
-            $this->assertSame(count($expectedListeners), $count);
+            self::assertSame(count($expectedListeners), $count);
         }
     }
 }

--- a/test/Listener/InitTriggerTest.php
+++ b/test/Listener/InitTriggerTest.php
@@ -41,6 +41,6 @@ class InitTriggerTest extends AbstractListenerTestCase
         $moduleManager->setModules(['ListenerTestModule']);
         $moduleManager->loadModules();
         $modules = $moduleManager->getLoadedModules();
-        $this->assertTrue($modules['ListenerTestModule']->initCalled);
+        self::assertTrue($modules['ListenerTestModule']->initCalled);
     }
 }

--- a/test/Listener/InitTriggerTest.php
+++ b/test/Listener/InitTriggerTest.php
@@ -24,7 +24,7 @@ class InitTriggerTest extends AbstractListenerTestCase
      */
     protected $moduleManager;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->moduleManager = new ModuleManager([]);
         $this->moduleManager->getEventManager()->attach(

--- a/test/Listener/ListenerOptionsTest.php
+++ b/test/Listener/ListenerOptionsTest.php
@@ -28,14 +28,14 @@ class ListenerOptionsTest extends TestCase
             'config_glob_paths'       => ['glob', 'paths'],
             'config_static_paths'       => ['static', 'custom_paths'],
         ]);
-        $this->assertSame($options->getCacheDir(), __DIR__);
-        $this->assertTrue($options->getConfigCacheEnabled());
-        $this->assertNotNull(strstr($options->getConfigCacheFile(), __DIR__));
-        $this->assertNotNull(strstr($options->getConfigCacheFile(), '.php'));
-        $this->assertSame('foo', $options->getConfigCacheKey());
-        $this->assertSame(['module', 'paths'], $options->getModulePaths());
-        $this->assertSame(['glob', 'paths'], $options->getConfigGlobPaths());
-        $this->assertSame(['static', 'custom_paths'], $options->getConfigStaticPaths());
+        self::assertSame($options->getCacheDir(), __DIR__);
+        self::assertTrue($options->getConfigCacheEnabled());
+        self::assertNotNull(strstr($options->getConfigCacheFile(), __DIR__));
+        self::assertNotNull(strstr($options->getConfigCacheFile(), '.php'));
+        self::assertSame('foo', $options->getConfigCacheKey());
+        self::assertSame(['module', 'paths'], $options->getModulePaths());
+        self::assertSame(['glob', 'paths'], $options->getConfigGlobPaths());
+        self::assertSame(['static', 'custom_paths'], $options->getConfigStaticPaths());
     }
 
     /**
@@ -51,9 +51,9 @@ class ListenerOptionsTest extends TestCase
            'config_static_paths'     => ['static', 'custom_paths'],
         ]);
 
-        $this->assertEquals(__DIR__ . '/module-config-cache.php', $options->getConfigCacheFile());
+        self::assertEquals(__DIR__ . '/module-config-cache.php', $options->getConfigCacheFile());
         $options->setConfigCacheKey('foo');
-        $this->assertEquals(__DIR__ . '/module-config-cache.foo.php', $options->getConfigCacheFile());
+        self::assertEquals(__DIR__ . '/module-config-cache.foo.php', $options->getConfigCacheFile());
     }
 
     /**
@@ -69,9 +69,9 @@ class ListenerOptionsTest extends TestCase
            'config_static_paths'      => ['static', 'custom_paths'],
         ]);
 
-        $this->assertEquals(__DIR__ . '/module-classmap-cache.php', $options->getModuleMapCacheFile());
+        self::assertEquals(__DIR__ . '/module-classmap-cache.php', $options->getModuleMapCacheFile());
         $options->setModuleMapCacheKey('foo');
-        $this->assertEquals(__DIR__ . '/module-classmap-cache.foo.php', $options->getModuleMapCacheFile());
+        self::assertEquals(__DIR__ . '/module-classmap-cache.foo.php', $options->getModuleMapCacheFile());
     }
 
     public function testCanAccessKeysAsProperties()
@@ -84,20 +84,20 @@ class ListenerOptionsTest extends TestCase
             'config_glob_paths'       => ['glob', 'paths'],
             'config_static_paths'       => ['static', 'custom_paths'],
         ]);
-        $this->assertSame($options->cache_dir, __DIR__);
+        self::assertSame($options->cache_dir, __DIR__);
         $options->cache_dir = 'foo';
-        $this->assertSame($options->cache_dir, 'foo');
-        $this->assertTrue(isset($options->cache_dir));
+        self::assertSame($options->cache_dir, 'foo');
+        self::assertTrue(isset($options->cache_dir));
         unset($options->cache_dir);
-        $this->assertFalse(isset($options->cache_dir));
+        self::assertFalse(isset($options->cache_dir));
 
-        $this->assertTrue($options->config_cache_enabled);
+        self::assertTrue($options->config_cache_enabled);
         $options->config_cache_enabled = false;
-        $this->assertFalse($options->config_cache_enabled);
-        $this->assertEquals('foo', $options->config_cache_key);
-        $this->assertSame(['module', 'paths'], $options->module_paths);
-        $this->assertSame(['glob', 'paths'], $options->config_glob_paths);
-        $this->assertSame(['static', 'custom_paths'], $options->config_static_paths);
+        self::assertFalse($options->config_cache_enabled);
+        self::assertEquals('foo', $options->config_cache_key);
+        self::assertSame(['module', 'paths'], $options->module_paths);
+        self::assertSame(['glob', 'paths'], $options->config_glob_paths);
+        self::assertSame(['static', 'custom_paths'], $options->config_static_paths);
     }
 
     public function testSetModulePathsAcceptsConfigOrTraverable()
@@ -105,7 +105,7 @@ class ListenerOptionsTest extends TestCase
         $config = new Config([__DIR__]);
         $options = new ListenerOptions;
         $options->setModulePaths($config);
-        $this->assertSame($config, $options->getModulePaths());
+        self::assertSame($config, $options->getModulePaths());
     }
 
     public function testSetModulePathsThrowsInvalidArgumentException()
@@ -120,7 +120,7 @@ class ListenerOptionsTest extends TestCase
         $config = new Config([__DIR__]);
         $options = new ListenerOptions;
         $options->setConfigGlobPaths($config);
-        $this->assertSame($config, $options->getConfigGlobPaths());
+        self::assertSame($config, $options->getConfigGlobPaths());
     }
 
     public function testSetConfigGlobPathsThrowsInvalidArgumentException()
@@ -143,11 +143,11 @@ class ListenerOptionsTest extends TestCase
         $traversable = new Config($array);
         $options = new ListenerOptions;
 
-        $this->assertSame($options, $options->setExtraConfig($array));
-        $this->assertSame($array, $options->getExtraConfig());
+        self::assertSame($options, $options->setExtraConfig($array));
+        self::assertSame($array, $options->getExtraConfig());
 
-        $this->assertSame($options, $options->setExtraConfig($traversable));
-        $this->assertSame($traversable, $options->getExtraConfig());
+        self::assertSame($options, $options->setExtraConfig($traversable));
+        self::assertSame($traversable, $options->getExtraConfig());
     }
 
     public function testSetExtraConfigThrowsInvalidArgumentException()

--- a/test/Listener/LocatorRegistrationListenerTest.php
+++ b/test/Listener/LocatorRegistrationListenerTest.php
@@ -132,7 +132,7 @@ class LocatorRegistrationListenerTest extends AbstractListenerTestCase
         $sharedInstance1 = $locator->get('ListenerTestModule\Module');
         $sharedInstance2 = $locator->get(ModuleManager::class);
 
-        $this->assertInstanceOf('ListenerTestModule\Module', $sharedInstance1);
+        self::assertInstanceOf('ListenerTestModule\Module', $sharedInstance1);
         $foo     = false;
         $message = '';
         try {
@@ -146,10 +146,10 @@ class LocatorRegistrationListenerTest extends AbstractListenerTestCase
         if (! $foo) {
             $this->fail($message);
         }
-        $this->assertSame($module, $foo->module);
+        self::assertSame($module, $foo->module);
 
-        $this->assertInstanceOf(ModuleManager::class, $sharedInstance2);
-        $this->assertSame($this->moduleManager, $locator->get('Foo\Bar')->moduleManager);
+        self::assertInstanceOf(ModuleManager::class, $sharedInstance2);
+        self::assertSame($this->moduleManager, $locator->get('Foo\Bar')->moduleManager);
     }
 
     public function testNoDuplicateServicesAreDefinedForModuleManager()
@@ -166,10 +166,10 @@ class LocatorRegistrationListenerTest extends AbstractListenerTestCase
         $aliases = $registeredServices['aliases'];
         $instances = $registeredServices['instances'];
 
-        $this->assertContains($this->normalizeServiceNameForContainer(ModuleManager::class, $container), $aliases);
-        $this->assertNotContains($this->normalizeServiceNameForContainer('ModuleManager', $container), $aliases);
+        self::assertContains($this->normalizeServiceNameForContainer(ModuleManager::class, $container), $aliases);
+        self::assertNotContains($this->normalizeServiceNameForContainer('ModuleManager', $container), $aliases);
 
-        $this->assertContains($this->normalizeServiceNameForContainer('ModuleManager', $container), $instances);
-        $this->assertNotContains($this->normalizeServiceNameForContainer(ModuleManager::class, $container), $instances);
+        self::assertContains($this->normalizeServiceNameForContainer('ModuleManager', $container), $instances);
+        self::assertNotContains($this->normalizeServiceNameForContainer(ModuleManager::class, $container), $instances);
     }
 }

--- a/test/Listener/LocatorRegistrationListenerTest.php
+++ b/test/Listener/LocatorRegistrationListenerTest.php
@@ -46,7 +46,7 @@ class LocatorRegistrationListenerTest extends AbstractListenerTestCase
      */
     protected $sharedEvents;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->sharedEvents = new SharedEventManager();
 

--- a/test/Listener/ModuleLoaderListenerTest.php
+++ b/test/Listener/ModuleLoaderListenerTest.php
@@ -54,15 +54,15 @@ class ModuleLoaderListenerTest extends AbstractListenerTestCase
         $events        = $moduleManager->getEventManager();
 
         $listeners     = iterator_to_array($this->getListenersForEvent(ModuleEvent::EVENT_LOAD_MODULES, $events));
-        $this->assertCount(1, $listeners);
+        self::assertCount(1, $listeners);
         $listeners     = iterator_to_array($this->getListenersForEvent(ModuleEvent::EVENT_LOAD_MODULES_POST, $events));
-        $this->assertCount(0, $listeners);
+        self::assertCount(0, $listeners);
 
         $moduleLoaderListener->attach($events);
         $listeners     = iterator_to_array($this->getListenersForEvent(ModuleEvent::EVENT_LOAD_MODULES, $events));
-        $this->assertCount(2, $listeners);
+        self::assertCount(2, $listeners);
         $listeners     = iterator_to_array($this->getListenersForEvent(ModuleEvent::EVENT_LOAD_MODULES_POST, $events));
-        $this->assertCount(1, $listeners);
+        self::assertCount(1, $listeners);
     }
 
     public function testModuleLoaderListenerFunctionsAsAggregateListenerDisabledCache()
@@ -77,15 +77,15 @@ class ModuleLoaderListenerTest extends AbstractListenerTestCase
         $events        = $moduleManager->getEventManager();
 
         $listeners     = iterator_to_array($this->getListenersForEvent(ModuleEvent::EVENT_LOAD_MODULES, $events));
-        $this->assertCount(1, $listeners);
+        self::assertCount(1, $listeners);
         $listeners     = iterator_to_array($this->getListenersForEvent(ModuleEvent::EVENT_LOAD_MODULES_POST, $events));
-        $this->assertCount(0, $listeners);
+        self::assertCount(0, $listeners);
 
         $moduleLoaderListener->attach($events);
         $listeners     = iterator_to_array($this->getListenersForEvent(ModuleEvent::EVENT_LOAD_MODULES, $events));
-        $this->assertCount(2, $listeners);
+        self::assertCount(2, $listeners);
         $listeners     = iterator_to_array($this->getListenersForEvent(ModuleEvent::EVENT_LOAD_MODULES_POST, $events));
-        $this->assertCount(0, $listeners);
+        self::assertCount(0, $listeners);
     }
 
     public function testModuleLoaderListenerFunctionsAsAggregateListenerHasCache()
@@ -104,14 +104,14 @@ class ModuleLoaderListenerTest extends AbstractListenerTestCase
         $events        = $moduleManager->getEventManager();
 
         $listeners     = iterator_to_array($this->getListenersForEvent(ModuleEvent::EVENT_LOAD_MODULES, $events));
-        $this->assertCount(1, $listeners);
+        self::assertCount(1, $listeners);
         $listeners     = iterator_to_array($this->getListenersForEvent(ModuleEvent::EVENT_LOAD_MODULES_POST, $events));
-        $this->assertCount(0, $listeners);
+        self::assertCount(0, $listeners);
 
         $moduleLoaderListener->attach($events);
         $listeners     = iterator_to_array($this->getListenersForEvent(ModuleEvent::EVENT_LOAD_MODULES, $events));
-        $this->assertCount(2, $listeners);
+        self::assertCount(2, $listeners);
         $listeners     = iterator_to_array($this->getListenersForEvent(ModuleEvent::EVENT_LOAD_MODULES_POST, $events));
-        $this->assertCount(0, $listeners);
+        self::assertCount(0, $listeners);
     }
 }

--- a/test/Listener/ModuleLoaderListenerTest.php
+++ b/test/Listener/ModuleLoaderListenerTest.php
@@ -30,7 +30,7 @@ class ModuleLoaderListenerTest extends AbstractListenerTestCase
      */
     protected $moduleManager;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->moduleManager = new ModuleManager([]);
         $this->moduleManager->getEventManager()->attach(

--- a/test/Listener/ModuleResolverListenerTest.php
+++ b/test/Listener/ModuleResolverListenerTest.php
@@ -28,7 +28,7 @@ class ModuleResolverListenerTest extends AbstractListenerTestCase
         $e = new ModuleEvent;
 
         $e->setModuleName($moduleName);
-        $this->assertInstanceOf($expectedInstanceOf, $moduleResolver($e));
+        self::assertInstanceOf($expectedInstanceOf, $moduleResolver($e));
     }
 
     public function validModuleNameProvider()
@@ -47,7 +47,7 @@ class ModuleResolverListenerTest extends AbstractListenerTestCase
         $e = new ModuleEvent;
 
         $e->setModuleName('DoesNotExist');
-        $this->assertFalse($moduleResolver($e));
+        self::assertFalse($moduleResolver($e));
     }
 
     public function testModuleResolverListenerPrefersModuleClassesInModuleNamespaceOverNamedClasses()
@@ -56,7 +56,7 @@ class ModuleResolverListenerTest extends AbstractListenerTestCase
         $e = new ModuleEvent;
 
         $e->setModuleName('ModuleAsClass');
-        $this->assertInstanceOf(ModuleAsClass\Module::class, $moduleResolver($e));
+        self::assertInstanceOf(ModuleAsClass\Module::class, $moduleResolver($e));
     }
 
     public function testModuleResolverListenerWillNotAttemptToResolveModuleAsClassNameGenerator()
@@ -65,6 +65,6 @@ class ModuleResolverListenerTest extends AbstractListenerTestCase
         $e = new ModuleEvent;
 
         $e->setModuleName('Generator');
-        $this->assertFalse($moduleResolver($e));
+        self::assertFalse($moduleResolver($e));
     }
 }

--- a/test/Listener/OnBootstrapListenerTest.php
+++ b/test/Listener/OnBootstrapListenerTest.php
@@ -74,6 +74,6 @@ class OnBootstrapListenerTest extends AbstractListenerTestCase
         $moduleManager->loadModules();
         $this->application->bootstrap();
         $modules = $moduleManager->getLoadedModules();
-        $this->assertTrue($modules['ListenerTestModule']->onBootstrapCalled);
+        self::assertTrue($modules['ListenerTestModule']->onBootstrapCalled);
     }
 }

--- a/test/Listener/OnBootstrapListenerTest.php
+++ b/test/Listener/OnBootstrapListenerTest.php
@@ -34,7 +34,7 @@ class OnBootstrapListenerTest extends AbstractListenerTestCase
      */
     protected $moduleManager;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         $sharedEvents = new SharedEventManager();
         $events       = new EventManager($sharedEvents);

--- a/test/Listener/ServiceListenerTest.php
+++ b/test/Listener/ServiceListenerTest.php
@@ -61,7 +61,7 @@ class ServiceListenerTest extends TestCase
      */
     protected $services;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->services = new ServiceManager();
         $this->listener = new ServiceListener($this->services);

--- a/test/Listener/ServiceListenerTest.php
+++ b/test/Listener/ServiceListenerTest.php
@@ -114,13 +114,13 @@ class ServiceListenerTest extends TestCase
         $this->listener->onLoadModulesPost($this->event);
         $services = $this->getConfiguredServiceManager();
 
-        $this->assertInstanceOf(ServiceManager::class, $services);
-        $this->assertSame($this->services, $services);
+        self::assertInstanceOf(ServiceManager::class, $services);
+        self::assertSame($this->services, $services);
 
-        $this->assertTrue($services->has(__CLASS__));
-        $this->assertTrue($services->has('foo'));
-        $this->assertTrue($services->has('bar'));
-        $this->assertTrue($services->has('resolved-by-abstract'));
+        self::assertTrue($services->has(__CLASS__));
+        self::assertTrue($services->has('foo'));
+        self::assertTrue($services->has('bar'));
+        self::assertTrue($services->has('resolved-by-abstract'));
     }
 
     public function assertServicesFromConfigArePresent(array $config, ServiceManager $serviceManager)
@@ -133,7 +133,7 @@ class ServiceListenerTest extends TestCase
                     // fall through
                 case 'aliases':
                     foreach (array_keys($services) as $service) {
-                        $this->assertTrue(
+                        self::assertTrue(
                             $serviceManager->has($service),
                             sprintf(
                                 'Service manager is missing expected service %s',
@@ -155,7 +155,7 @@ class ServiceListenerTest extends TestCase
         $this->event->setModule($module);
         $this->listener->onLoadModule($this->event);
 
-        $this->assertSame($this->services, $this->getConfiguredServiceManager());
+        self::assertSame($this->services, $this->getConfiguredServiceManager());
     }
 
     public function testInvalidReturnFromModuleDoesNothing()
@@ -164,7 +164,7 @@ class ServiceListenerTest extends TestCase
         $this->event->setModule($module);
         $this->listener->onLoadModule($this->event);
 
-        $this->assertSame($this->services, $this->getConfiguredServiceManager());
+        self::assertSame($this->services, $this->getConfiguredServiceManager());
     }
 
     public function testModuleReturningArrayConfiguresServiceManager()
@@ -174,7 +174,7 @@ class ServiceListenerTest extends TestCase
         $this->event->setModule($module);
         $this->listener->onLoadModule($this->event);
         $services = $this->getConfiguredServiceManager();
-        $this->assertServiceManagerConfiguration();
+        self::assertServiceManagerConfiguration();
     }
 
     public function testModuleReturningTraversableConfiguresServiceManager()
@@ -184,7 +184,7 @@ class ServiceListenerTest extends TestCase
         $module = new TestAsset\ServiceProviderModule($config);
         $this->event->setModule($module);
         $this->listener->onLoadModule($this->event);
-        $this->assertServiceManagerConfiguration();
+        self::assertServiceManagerConfiguration();
     }
 
     public function testModuleServiceConfigOverridesGlobalConfig()
@@ -208,9 +208,9 @@ class ServiceListenerTest extends TestCase
         $this->listener->onLoadModulesPost($this->event);
 
         $services = $this->getConfiguredServiceManager();
-        $this->assertTrue($services->has('foo'));
-        $this->assertNotSame($services->get('foo'), $services->get('bar'));
-        $this->assertSame($services->get('foo'), $services->get('baz'));
+        self::assertTrue($services->has('foo'));
+        self::assertNotSame($services->get('foo'), $services->get('bar'));
+        self::assertSame($services->get('foo'), $services->get('baz'));
     }
 
     public function testModuleReturningServiceConfigConfiguresServiceManager()
@@ -220,7 +220,7 @@ class ServiceListenerTest extends TestCase
         $module = new TestAsset\ServiceProviderModule($config);
         $this->event->setModule($module);
         $this->listener->onLoadModule($this->event);
-        $this->assertServiceManagerConfiguration();
+        self::assertServiceManagerConfiguration();
     }
 
     public function testMergedConfigContainingServiceManagerKeyWillConfigureServiceManagerPostLoadModules()
@@ -229,7 +229,7 @@ class ServiceListenerTest extends TestCase
         $configListener = new ConfigListener();
         $configListener->setMergedConfig($config);
         $this->event->setConfigListener($configListener);
-        $this->assertServiceManagerConfiguration();
+        self::assertServiceManagerConfiguration();
     }
 
     public function invalidServiceManagerTypes()
@@ -282,12 +282,12 @@ class ServiceListenerTest extends TestCase
         $listener->onLoadModulesPost($this->event);
 
         $configuredServices = $this->getConfiguredServiceManager($listener);
-        $this->assertSame($services, $configuredServices);
-        $this->assertTrue($configuredServices->has('CustomPluginManager'));
+        self::assertSame($services, $configuredServices);
+        self::assertTrue($configuredServices->has('CustomPluginManager'));
         $plugins = $configuredServices->get('CustomPluginManager');
-        $this->assertInstanceOf(TestAsset\CustomPluginManager::class, $plugins);
+        self::assertInstanceOf(TestAsset\CustomPluginManager::class, $plugins);
 
-        $this->assertServicesFromConfigArePresent($pluginConfig, $plugins);
+        self::assertServicesFromConfigArePresent($pluginConfig, $plugins);
     }
 
     public function testCreatesPluginManagerBasedOnModuleDuckTypingSpecifiedProviderInterface()
@@ -310,26 +310,26 @@ class ServiceListenerTest extends TestCase
         $listener->onLoadModulesPost($this->event);
 
         $configuredServices = $this->getConfiguredServiceManager($listener);
-        $this->assertSame($services, $configuredServices);
-        $this->assertTrue($configuredServices->has('CustomPluginManager'));
+        self::assertSame($services, $configuredServices);
+        self::assertTrue($configuredServices->has('CustomPluginManager'));
         $plugins = $configuredServices->get('CustomPluginManager');
-        $this->assertInstanceOf(TestAsset\CustomPluginManager::class, $plugins);
+        self::assertInstanceOf(TestAsset\CustomPluginManager::class, $plugins);
 
-        $this->assertServicesFromConfigArePresent($pluginConfig, $plugins);
+        self::assertServicesFromConfigArePresent($pluginConfig, $plugins);
     }
 
     public function testAttachesListenersAtExpectedPriorities()
     {
         $events = new EventManager();
         $this->listener->attach($events);
-        $this->assertListenerAtPriority(
+        self::assertListenerAtPriority(
             [$this->listener, 'onLoadModule'],
             1,
             ModuleEvent::EVENT_LOAD_MODULE,
             $events,
             'onLoadModule not registered at expected priority'
         );
-        $this->assertListenerAtPriority(
+        self::assertListenerAtPriority(
             [$this->listener, 'onLoadModulesPost'],
             1,
             ModuleEvent::EVENT_LOAD_MODULES_POST,
@@ -354,9 +354,9 @@ class ServiceListenerTest extends TestCase
         $listener->detach($events);
 
         $listeners = $this->getArrayOfListenersForEvent(ModuleEvent::EVENT_LOAD_MODULE, $events);
-        $this->assertCount(0, $listeners);
+        self::assertCount(0, $listeners);
         $listeners = $this->getArrayOfListenersForEvent(ModuleEvent::EVENT_LOAD_MODULES_POST, $events);
-        $this->assertCount(0, $listeners);
+        self::assertCount(0, $listeners);
     }
 
     public function testListenerCanOverrideServicesInServiceManagers()
@@ -393,10 +393,10 @@ class ServiceListenerTest extends TestCase
         $listener->onLoadModule($event);
         $listener->onLoadModulesPost($event);
 
-        $this->assertTrue($services->has('config'));
-        $this->assertTrue($services->has('foo'));
-        $this->assertEquals(['foo' => 'bar'], $services->get('config'), 'Config service was not overridden');
-        $this->assertInstanceOf(stdClass::class, $services->get('foo'), 'Foo service was not overridden');
+        self::assertTrue($services->has('config'));
+        self::assertTrue($services->has('foo'));
+        self::assertEquals(['foo' => 'bar'], $services->get('config'), 'Config service was not overridden');
+        self::assertInstanceOf(stdClass::class, $services->get('foo'), 'Foo service was not overridden');
     }
 
     public function testOnLoadModulesPostShouldNotRaiseExceptionIfNamedServiceManagerDoesNotExist()
@@ -422,7 +422,7 @@ class ServiceListenerTest extends TestCase
 
         try {
             $listener->onLoadModulesPost($event);
-            $this->assertFalse($services->has('UndefinedPluginManager'));
+            self::assertFalse($services->has('UndefinedPluginManager'));
         } catch (\Exception $e) {
             $this->fail('Exception should not be raised when encountering unknown plugin manager services');
         }

--- a/test/ModuleEventTest.php
+++ b/test/ModuleEventTest.php
@@ -24,7 +24,7 @@ class ModuleEventTest extends TestCase
      */
     protected $event;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->event = new ModuleEvent();
     }

--- a/test/ModuleEventTest.php
+++ b/test/ModuleEventTest.php
@@ -34,7 +34,7 @@ class ModuleEventTest extends TestCase
         $module = new stdClass;
         $this->event->setModule($module);
         $test = $this->event->getModule();
-        $this->assertSame($module, $test);
+        self::assertSame($module, $test);
     }
 
     public function testPassingNonObjectToSetModuleRaisesException()
@@ -48,7 +48,7 @@ class ModuleEventTest extends TestCase
         $moduleName = 'MyModule';
         $this->event->setModuleName($moduleName);
         $test = $this->event->getModuleName();
-        $this->assertSame($moduleName, $test);
+        self::assertSame($moduleName, $test);
     }
 
     public function testPassingNonStringToSetModuleNameRaisesException()
@@ -62,7 +62,7 @@ class ModuleEventTest extends TestCase
         $configListener = new ConfigListener;
         $this->event->setConfigListener($configListener);
         $test = $this->event->getParam('configListener');
-        $this->assertSame($configListener, $test);
+        self::assertSame($configListener, $test);
     }
 
     public function testCanRetrieveConfigListenerViaGetter()
@@ -70,6 +70,6 @@ class ModuleEventTest extends TestCase
         $configListener = new ConfigListener;
         $this->event->setConfigListener($configListener);
         $test = $this->event->getConfigListener();
-        $this->assertSame($configListener, $test);
+        self::assertSame($configListener, $test);
     }
 }

--- a/test/ModuleManagerTest.php
+++ b/test/ModuleManagerTest.php
@@ -33,7 +33,7 @@ class ModuleManagerTest extends TestCase
      */
     protected $defaultListeners;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->sharedEvents = new SharedEventManager;
         $this->events       = new EventManager($this->sharedEvents);

--- a/test/ModuleManagerTest.php
+++ b/test/ModuleManagerTest.php
@@ -51,7 +51,7 @@ class ModuleManagerTest extends TestCase
         $moduleManager = new ModuleManager([]);
         $identifiers = $moduleManager->getEventManager()->getIdentifiers();
         $expected    = ['Laminas\ModuleManager\ModuleManager', 'module_manager'];
-        $this->assertEquals($expected, array_values($identifiers));
+        self::assertEquals($expected, array_values($identifiers));
     }
 
     public function testCanLoadSomeModule()
@@ -61,9 +61,9 @@ class ModuleManagerTest extends TestCase
         $this->defaultListeners->attach($this->events);
         $moduleManager->loadModules();
         $loadedModules = $moduleManager->getLoadedModules();
-        $this->assertInstanceOf('SomeModule\Module', $loadedModules['SomeModule']);
+        self::assertInstanceOf('SomeModule\Module', $loadedModules['SomeModule']);
         $config = $configListener->getMergedConfig();
-        $this->assertSame($config->some, 'thing', var_export($config, true));
+        self::assertSame($config->some, 'thing', var_export($config, true));
     }
 
     public function testCanLoadMultipleModules()
@@ -73,16 +73,16 @@ class ModuleManagerTest extends TestCase
         $this->defaultListeners->attach($this->events);
         $moduleManager->loadModules();
         $loadedModules = $moduleManager->getLoadedModules();
-        $this->assertInstanceOf('BarModule\Module', $loadedModules['BarModule']);
-        $this->assertInstanceOf('BazModule\Module', $loadedModules['BazModule']);
-        $this->assertInstanceOf('SubModule\Sub\Module', $loadedModules['SubModule\Sub']);
-        $this->assertInstanceOf('BarModule\Module', $moduleManager->getModule('BarModule'));
-        $this->assertInstanceOf('BazModule\Module', $moduleManager->getModule('BazModule'));
-        $this->assertInstanceOf('SubModule\Sub\Module', $moduleManager->getModule('SubModule\Sub'));
-        $this->assertNull($moduleManager->getModule('NotLoaded'));
+        self::assertInstanceOf('BarModule\Module', $loadedModules['BarModule']);
+        self::assertInstanceOf('BazModule\Module', $loadedModules['BazModule']);
+        self::assertInstanceOf('SubModule\Sub\Module', $loadedModules['SubModule\Sub']);
+        self::assertInstanceOf('BarModule\Module', $moduleManager->getModule('BarModule'));
+        self::assertInstanceOf('BazModule\Module', $moduleManager->getModule('BazModule'));
+        self::assertInstanceOf('SubModule\Sub\Module', $moduleManager->getModule('SubModule\Sub'));
+        self::assertNull($moduleManager->getModule('NotLoaded'));
         $config = $configListener->getMergedConfig();
-        $this->assertSame('foo', $config->bar);
-        $this->assertSame('bar', $config->baz);
+        self::assertSame('foo', $config->bar);
+        self::assertSame('bar', $config->baz);
     }
 
     public function testModuleLoadingBehavior()
@@ -90,13 +90,13 @@ class ModuleManagerTest extends TestCase
         $moduleManager = new ModuleManager(['BarModule'], $this->events);
         $this->defaultListeners->attach($this->events);
         $modules = $moduleManager->getLoadedModules();
-        $this->assertSame(0, count($modules));
+        self::assertSame(0, count($modules));
         $modules = $moduleManager->getLoadedModules(true);
-        $this->assertSame(1, count($modules));
+        self::assertSame(1, count($modules));
         $moduleManager->loadModules(); // should not cause any problems
         $moduleManager->loadModule('BarModule'); // should not cause any problems
         $modules = $moduleManager->getLoadedModules(true); // BarModule already loaded so nothing happens
-        $this->assertSame(1, count($modules));
+        self::assertSame(1, count($modules));
     }
 
     public function testConstructorThrowsInvalidArgumentException()
@@ -120,8 +120,8 @@ class ModuleManagerTest extends TestCase
         $moduleManager->loadModules();
 
         $config = $configListener->getMergedConfig();
-        $this->assertTrue(isset($config['loaded']));
-        $this->assertSame('oh, yeah baby!', $config['loaded']);
+        self::assertTrue(isset($config['loaded']));
+        self::assertSame('oh, yeah baby!', $config['loaded']);
     }
 
     /**
@@ -135,8 +135,8 @@ class ModuleManagerTest extends TestCase
         $moduleManager->loadModules();
 
         $config = $configListener->getMergedConfig();
-        $this->assertTrue(isset($config['baz']));
-        $this->assertSame('bar', $config['baz']);
+        self::assertTrue(isset($config['baz']));
+        self::assertSame('bar', $config['baz']);
     }
 
     /**
@@ -152,11 +152,11 @@ class ModuleManagerTest extends TestCase
 
         $config = $configListener->getMergedConfig();
 
-        $this->assertTrue(isset($config['bar']));
-        $this->assertSame('bar', $config['bar']);
+        self::assertTrue(isset($config['bar']));
+        self::assertSame('bar', $config['bar']);
 
-        $this->assertTrue(isset($config['foo']));
-        $this->assertSame('bar', $config['foo']);
+        self::assertTrue(isset($config['foo']));
+        self::assertSame('bar', $config['foo']);
     }
 
     public function testModuleIsMarkedAsLoadedWhenLoadModuleEventIsTriggered()
@@ -171,9 +171,9 @@ class ModuleManagerTest extends TestCase
 
         $moduleManager->loadModules();
 
-        $this->assertTrue(isset($test->modules));
-        $this->assertArrayHasKey('BarModule', $test->modules);
-        $this->assertInstanceOf('BarModule\Module', $test->modules['BarModule']);
+        self::assertTrue(isset($test->modules));
+        self::assertArrayHasKey('BarModule', $test->modules);
+        self::assertInstanceOf('BarModule\Module', $test->modules['BarModule']);
     }
 
     public function testCanLoadSomeObjectModule()
@@ -188,9 +188,9 @@ class ModuleManagerTest extends TestCase
         $this->defaultListeners->attach($this->events);
         $moduleManager->loadModules();
         $loadedModules = $moduleManager->getLoadedModules();
-        $this->assertInstanceOf('SomeModule\Module', $loadedModules['SomeModule']);
+        self::assertInstanceOf('SomeModule\Module', $loadedModules['SomeModule']);
         $config = $configListener->getMergedConfig();
-        $this->assertSame($config->some, 'thing');
+        self::assertSame($config->some, 'thing');
     }
 
     public function testCanLoadMultipleModulesObjectWithString()
@@ -201,9 +201,9 @@ class ModuleManagerTest extends TestCase
         $this->defaultListeners->attach($this->events);
         $moduleManager->loadModules();
         $loadedModules = $moduleManager->getLoadedModules();
-        $this->assertInstanceOf('SomeModule\Module', $loadedModules['SomeModule']);
+        self::assertInstanceOf('SomeModule\Module', $loadedModules['SomeModule']);
         $config = $configListener->getMergedConfig();
-        $this->assertSame($config->some, 'thing');
+        self::assertSame($config->some, 'thing');
     }
 
     public function testCanNotLoadSomeObjectModuleWithoutIdentifier()
@@ -223,15 +223,15 @@ class ModuleManagerTest extends TestCase
 
         $moduleManager->setEvent($event);
 
-        $this->assertSame($event, $moduleManager->getEvent());
-        $this->assertSame($moduleManager, $event->getTarget());
+        self::assertSame($event, $moduleManager->getEvent());
+        self::assertSame($moduleManager, $event->getTarget());
     }
 
     public function testGetEventWillLazyLoadOneWithTargetSetToModuleManager()
     {
         $moduleManager = new ModuleManager([]);
         $event = $moduleManager->getEvent();
-        $this->assertInstanceOf(ModuleEvent::class, $event);
-        $this->assertSame($moduleManager, $event->getTarget());
+        self::assertInstanceOf(ModuleEvent::class, $event);
+        self::assertSame($moduleManager, $event->getTarget());
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description
Bumps minimum PHP to 7.3 that is in active support

Update PHPunit , drop versions for php 5.6