### PR TITLE
Adds webimpress/safe-writer to write cache files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- [#9](https://github.com/laminas/laminas-modulemanager/pull/9) adds [webimpress/safe-writer](https://github.com/webimpress/safe-writer) for saving cache files safely to avoid race conditions when the same file is written multiple times in a short time period. 
 
 ### Changed
 

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "laminas/laminas-eventmanager": "^3.2 || ^2.6.3",
         "laminas/laminas-stdlib": "^3.1 || ^2.7",
         "laminas/laminas-zendframework-bridge": "^1.0",
-        "webimpress/safe-writer": "^1.0.2 || ^2.0.1"
+        "webimpress/safe-writer": "^1.0.2 || ^2.1"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
         "laminas/laminas-config": "^3.1 || ^2.6",
         "laminas/laminas-eventmanager": "^3.2 || ^2.6.3",
         "laminas/laminas-stdlib": "^3.1 || ^2.7",
-        "laminas/laminas-zendframework-bridge": "^1.0"
+        "laminas/laminas-zendframework-bridge": "^1.0",
+        "webimpress/safe-writer": "^1.0.2 || ^2.0.1"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~1.0.0",

--- a/src/Listener/AbstractListener.php
+++ b/src/Listener/AbstractListener.php
@@ -8,6 +8,8 @@
 
 namespace Laminas\ModuleManager\Listener;
 
+use Webimpress\SafeWriter\FileWriter;
+
 /**
  * Abstract listener
  */
@@ -60,17 +62,8 @@ abstract class AbstractListener
      */
     protected function writeArrayToFile($filePath, $array)
     {
-        // Write cache file to temporary file first and then rename it.
-        // We don't want cache file to be read when it is not written completely.
-        // include/require functions require additional lock, see:
-        // https://bugs.php.net/bug.php?id=52895
-        $tmp = tempnam(sys_get_temp_dir(), md5($filePath));
-
         $content = "<?php\nreturn " . var_export($array, true) . ';';
-        file_put_contents($tmp, $content);
-        chmod($tmp, 0666 & ~umask());
-
-        rename($tmp, $filePath);
+        FileWriter::writeFile($filePath, $content);
 
         return $this;
     }


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

Library [webimpress/safe-writer](https://github.com/webimpress/safe-writer) has a function to safe write cache files to avoid race conditions when the same file is written multiple times in a short time period.

/cc @kynx

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
