### PR TITLE
Fix superfluous traling semicolon in cached config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 2.11.0 - TBD
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
 ## 2.10.1 - TBD
 
 ### Added

--- a/src/Listener/AbstractListener.php
+++ b/src/Listener/AbstractListener.php
@@ -69,7 +69,7 @@ abstract class AbstractListener
             $content = "<?php\n" . VarExporter::export(
                 $array,
                 VarExporter::ADD_RETURN | VarExporter::CLOSURE_SNAPSHOT_USES
-            ) . ';';
+            );
         } catch (ExportException $e) {
             throw ConfigCannotBeCachedException::fromExporterException($e);
         }


### PR DESCRIPTION
The trailing semicolon gets already yielded by `VarExporter::export`.

|    Q          |   A
|-------------- | ------
| Bugfix        | yes(ish)


The generated cache file contained an extra semicolon:

```
<?php
return [
    'service_manager' => [
    ]
];
;
```

This is more of an cosmetic fix as the traling semicolon should not have any negativ impact.