### PR TITLE
Add configCacheFileMode option

### DIFF
--- a/src/Listener/AbstractListener.php
+++ b/src/Listener/AbstractListener.php
@@ -61,9 +61,10 @@ abstract class AbstractListener
      *
      * @param  string $filePath
      * @param  array $array
+     * @param  int $fileMode
      * @return AbstractListener
      */
-    protected function writeArrayToFile($filePath, $array)
+    protected function writeArrayToFile($filePath, $array, $fileMode = 0666)
     {
         try {
             $content = "<?php\n" . VarExporter::export(
@@ -74,7 +75,7 @@ abstract class AbstractListener
             throw ConfigCannotBeCachedException::fromExporterException($e);
         }
 
-        FileWriter::writeFile($filePath, $content);
+        FileWriter::writeFile($filePath, $content, $fileMode);
 
         return $this;
     }

--- a/src/Listener/ConfigListener.php
+++ b/src/Listener/ConfigListener.php
@@ -180,7 +180,8 @@ class ConfigListener extends AbstractListener implements
             && false === $this->skipConfig
         ) {
             $configFile = $this->getOptions()->getConfigCacheFile();
-            $this->writeArrayToFile($configFile, $this->getMergedConfig(false));
+            $configFileMode = $this->getOptions()->getConfigCacheFileMode();
+            $this->writeArrayToFile($configFile, $this->getMergedConfig(false), $configFileMode);
         }
 
         return $this;

--- a/src/Listener/ListenerOptions.php
+++ b/src/Listener/ListenerOptions.php
@@ -53,6 +53,11 @@ class ListenerOptions extends AbstractOptions
     protected $configCacheKey;
 
     /**
+     * @var int
+     */
+    protected $configCacheFileMode = 0666;
+
+    /**
      * @var string|null
      */
     protected $cacheDir;
@@ -281,6 +286,28 @@ class ListenerOptions extends AbstractOptions
         }
 
         return $this->getCacheDir() . '/module-config-cache.php';
+    }
+
+    /**
+     * Get permission mode used to create the cache file name
+     *
+     * @return int
+     */
+    public function getConfigCacheFileMode()
+    {
+        return $this->configCacheFileMode;
+    }
+
+    /**
+     * Set permission mode used to create the cache file name
+     *
+     * @param int $configCacheFileMode
+     * @return ListenerOptions
+     */
+    public function setConfigCacheFileMode($configCacheFileMode)
+    {
+        $this->configCacheFileMode = $configCacheFileMode;
+        return $this;
     }
 
     /**

--- a/test/Listener/ListenerOptionsTest.php
+++ b/test/Listener/ListenerOptionsTest.php
@@ -26,6 +26,7 @@ class ListenerOptionsTest extends TestCase
             'cache_dir'               => __DIR__,
             'config_cache_enabled'    => true,
             'config_cache_key'        => 'foo',
+            'config_cache_file_mode'  => 0123,
             'module_paths'            => ['module', 'paths'],
             'config_glob_paths'       => ['glob', 'paths'],
             'config_static_paths'       => ['static', 'custom_paths'],
@@ -35,6 +36,7 @@ class ListenerOptionsTest extends TestCase
         self::assertNotNull(strstr($options->getConfigCacheFile(), __DIR__));
         self::assertNotNull(strstr($options->getConfigCacheFile(), '.php'));
         self::assertSame('foo', $options->getConfigCacheKey());
+        self::assertSame(0123, $options->getConfigCacheFileMode());
         self::assertSame(['module', 'paths'], $options->getModulePaths());
         self::assertSame(['glob', 'paths'], $options->getConfigGlobPaths());
         self::assertSame(['static', 'custom_paths'], $options->getConfigStaticPaths());


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

Tell us about why this change is necessary:
Config file can contain some secret information, which should not be readible for all users in server.
So I need to provide config file permission configCacheFileMode option, e.g. 0600.

- Are you adding documentation?
  - No

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - I've added test for new option 

- Are you fixing a BC Break?
  - Threre is no BC Break

- Are you adding something the library currently does not support?
  - Вescribed above

- Are you refactoring code?
  - No
