### PR TITLE
fix - loadModule reinitializes modules if the module has already been…

### DIFF
--- a/src/ModuleManager.php
+++ b/src/ModuleManager.php
@@ -346,7 +346,7 @@ class ModuleManager implements ModuleManagerInterface
     {
         $verifiedModulName = $moduleName;
 
-        if (!class_exists($moduleName) && class_exists($moduleName . '\Module')) {
+        if (! class_exists($moduleName) && class_exists($moduleName . '\Module')) {
             $verifiedModulName = $moduleName . '\Module';
         }
 

--- a/src/ModuleManager.php
+++ b/src/ModuleManager.php
@@ -6,8 +6,10 @@ namespace Laminas\ModuleManager;
 
 use Laminas\EventManager\EventManager;
 use Laminas\EventManager\EventManagerInterface;
+use ReflectionClass;
 use Traversable;
 
+use function class_exists;
 use function current;
 use function get_class;
 use function is_array;
@@ -141,7 +143,7 @@ class ModuleManager implements ModuleManagerInterface
 
         // when no class-string is found, try search for a namespace
         if (class_exists($verifiedModulName)) {
-            $moduleReflection = new \ReflectionClass($verifiedModulName);
+            $moduleReflection = new ReflectionClass($verifiedModulName);
 
             if (isset($this->loadedModules[$moduleReflection->getNamespaceName()])) {
                 return $this->loadedModules[$moduleReflection->getNamespaceName()];
@@ -337,15 +339,15 @@ class ModuleManager implements ModuleManagerInterface
     /**
      * determines the class string of the module
      *
-     * @param $moduleName
+     * @param string $moduleName
      * @return string
      */
     private function getVerifiedModuleName($moduleName)
     {
         $verifiedModulName = $moduleName;
 
-        if (!class_exists($moduleName) && class_exists($moduleName.'\Module')) {
-            $verifiedModulName = $moduleName.'\Module';
+        if (!class_exists($moduleName) && class_exists($moduleName . '\Module')) {
+            $verifiedModulName = $moduleName . '\Module';
         }
 
         return $verifiedModulName;

--- a/src/ModuleManager.php
+++ b/src/ModuleManager.php
@@ -128,8 +128,24 @@ class ModuleManager implements ModuleManagerInterface
             $module     = current($module);
         }
 
+        // search for a specific name
         if (isset($this->loadedModules[$moduleName])) {
             return $this->loadedModules[$moduleName];
+        }
+
+        // when no specific name is found, try the complete class-string
+        $verifiedModulName = $this->getVerifiedModuleName($moduleName);
+        if (isset($this->loadedModules[$verifiedModulName])) {
+            return $this->loadedModules[$verifiedModulName];
+        }
+
+        // when no class-string is found, try search for a namespace
+        if (class_exists($verifiedModulName)) {
+            $moduleReflection = new \ReflectionClass($verifiedModulName);
+
+            if (isset($this->loadedModules[$moduleReflection->getNamespaceName()])) {
+                return $this->loadedModules[$moduleReflection->getNamespaceName()];
+            }
         }
 
         /*
@@ -316,5 +332,22 @@ class ModuleManager implements ModuleManagerInterface
     protected function attachDefaultListeners($events)
     {
         $events->attach(ModuleEvent::EVENT_LOAD_MODULES, [$this, 'onLoadModules']);
+    }
+
+    /**
+     * determines the class string of the module
+     *
+     * @param $moduleName
+     * @return string
+     */
+    private function getVerifiedModuleName($moduleName)
+    {
+        $verifiedModulName = $moduleName;
+
+        if (!class_exists($moduleName) && class_exists($moduleName.'\Module')) {
+            $verifiedModulName = $moduleName.'\Module';
+        }
+
+        return $verifiedModulName;
     }
 }

--- a/test/ModuleManagerTest.php
+++ b/test/ModuleManagerTest.php
@@ -108,8 +108,6 @@ class ModuleManagerTest extends TestCase
         self::assertSame(0, count($modules));
         $modules = $moduleManager->getLoadedModules(true);
         self::assertSame(1, count($modules));
-
-
         $moduleManager->loadModules(); // should not cause any problems
         $moduleManager->loadModule(Module::class); // should not cause any problems
         $modules = $moduleManager->getLoadedModules(true); // BarModule already loaded so nothing happens
@@ -124,8 +122,6 @@ class ModuleManagerTest extends TestCase
         self::assertSame(0, count($modules));
         $modules = $moduleManager->getLoadedModules(true);
         self::assertSame(1, count($modules));
-
-
         $moduleManager->loadModules(); // should not cause any problems
         $moduleManager->loadModule('SomeModule'); // should not cause any problems
         $modules = $moduleManager->getLoadedModules(true); // BarModule already loaded so nothing happens

--- a/test/ModuleManagerTest.php
+++ b/test/ModuleManagerTest.php
@@ -111,14 +111,14 @@ class ModuleManagerTest extends TestCase
 
 
         $moduleManager->loadModules(); // should not cause any problems
-        $moduleManager->loadModule(\SomeModule\Module::class); // should not cause any problems
+        $moduleManager->loadModule(Module::class); // should not cause any problems
         $modules = $moduleManager->getLoadedModules(true); // BarModule already loaded so nothing happens
         self::assertSame(1, count($modules));
     }
 
     public function testModuleLoadingBehaviorWithModuleClassStringsVersion2()
     {
-        $moduleManager = new ModuleManager([\SomeModule\Module::class], $this->events);
+        $moduleManager = new ModuleManager([Module::class], $this->events);
         $this->defaultListeners->attach($this->events);
         $modules = $moduleManager->getLoadedModules();
         self::assertSame(0, count($modules));

--- a/test/ModuleManagerTest.php
+++ b/test/ModuleManagerTest.php
@@ -100,6 +100,38 @@ class ModuleManagerTest extends TestCase
         self::assertSame(1, count($modules));
     }
 
+    public function testModuleLoadingBehaviorWithModuleClassStrings()
+    {
+        $moduleManager = new ModuleManager(['SomeModule'], $this->events);
+        $this->defaultListeners->attach($this->events);
+        $modules = $moduleManager->getLoadedModules();
+        self::assertSame(0, count($modules));
+        $modules = $moduleManager->getLoadedModules(true);
+        self::assertSame(1, count($modules));
+
+
+        $moduleManager->loadModules(); // should not cause any problems
+        $moduleManager->loadModule(\SomeModule\Module::class); // should not cause any problems
+        $modules = $moduleManager->getLoadedModules(true); // BarModule already loaded so nothing happens
+        self::assertSame(1, count($modules));
+    }
+
+    public function testModuleLoadingBehaviorWithModuleClassStringsVersion2()
+    {
+        $moduleManager = new ModuleManager([\SomeModule\Module::class], $this->events);
+        $this->defaultListeners->attach($this->events);
+        $modules = $moduleManager->getLoadedModules();
+        self::assertSame(0, count($modules));
+        $modules = $moduleManager->getLoadedModules(true);
+        self::assertSame(1, count($modules));
+
+
+        $moduleManager->loadModules(); // should not cause any problems
+        $moduleManager->loadModule('SomeModule'); // should not cause any problems
+        $modules = $moduleManager->getLoadedModules(true); // BarModule already loaded so nothing happens
+        self::assertSame(1, count($modules));
+    }
+
     public function testConstructorThrowsInvalidArgumentException()
     {
         $this->expectException(InvalidArgumentException::class);


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

As descripted in #32 . there is an bug when loading a module with another loading name. there are currently 3 ways to load the same module via the module manager. the following options are available:

* namespace (legacy way)
* direct class string of the module class
* an array with "free name (string)" (key) and a module class object (value)

if you use method 1 (namespace) and method 2 (class string) for the same module in an application, it will be loaded twice and reset the previous settings.

this pull request fixes the false behavior and prevents a module from being loaded twice.

fixes #32